### PR TITLE
build 0.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 563339e807e53ffd9c267e99fc6d9ea23eb8443c08f112651963e24e22f84a5d
 
 build:
-  noarch: python
+  skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   number: 0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,21 +6,21 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/annotated_types-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 563339e807e53ffd9c267e99fc6d9ea23eb8443c08f112651963e24e22f84a5d
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   number: 0
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
     - hatchling
   run:
-    - python >=3.7
+    - python
     - typing-extensions >=4.0.0
 
 test:
@@ -32,10 +32,18 @@ test:
     - pip
 
 about:
-  home: https://pypi.org/project/annotated-types/
+  home: https://pypi.org/project/annotated-types
   summary: Reusable constraint types to use with typing.Annotated
+  description: |
+    This package provides metadata objects which can be used to represent common constraints such as upper and lower
+    bounds on scalar values and collection sizes, a Predicate marker for runtime checks, and descriptions of how we
+    intend these metadata to be interpreted. In some cases, we also note alternative representations which do not
+    require this package.
   license: MIT
   license_file: LICENSE
+  license_family: MIT
+  doc_url: https://pypi.org/project/annotated-types
+  dev_url: https://pypi.org/project/annotated-types
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,12 +25,16 @@ requirements:
     - typing-extensions >=4.0.0
 
 test:
+  source_files:
+    - tests
   imports:
     - annotated_types
   commands:
     - pip check
+    - pytest -v tests
   requires:
     - pip
+    - pytest
 
 about:
   home: https://github.com/annotated-types/annotated-types

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - hatchling
   run:
     - python
-    - typing-extensions >=4.0.0
+    - typing-extensions >=4.0.0 # [py<39]
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
 {% set name = "annotated-types" %}
+{% set alt_name = name.replace('-','_') %}
 {% set version = "0.6.0" %}
 
 package:
@@ -6,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ alt_name }}/{{ alt_name }}-{{ version }}.tar.gz
   sha256: 563339e807e53ffd9c267e99fc6d9ea23eb8443c08f112651963e24e22f84a5d
 
 build:
@@ -32,7 +33,7 @@ test:
     - pip
 
 about:
-  home: https://pypi.org/project/annotated-types
+  home: https://github.com/annotated-types/annotated-types
   summary: Reusable constraint types to use with typing.Annotated
   description: |
     This package provides metadata objects which can be used to represent common constraints such as upper and lower
@@ -42,8 +43,8 @@ about:
   license: MIT
   license_file: LICENSE
   license_family: MIT
-  doc_url: https://pypi.org/project/annotated-types
-  dev_url: https://pypi.org/project/annotated-types
+  doc_url: https://github.com/annotated-types/annotated-types
+  dev_url: https://github.com/annotated-types/annotated-types
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
annotated-types 0.6.0

**Destination channel:** defaults

### Links

- [PKG-4140]
- [Upstream repository](https://github.com/annotated-types/annotated-types/tree/v0.6.0)
    

[PKG-4140]: https://anaconda.atlassian.net/browse/PKG-4140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ